### PR TITLE
[Issue 21] Add support for async tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 *.pyo
 *.egg-info
 .eggs
+.pytest_cache
 /dist
 /build

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 *.pyo
 *.egg-info
+.eggs
 /dist
 /build

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ env:
  - REQUESTS="requests" # latest
  - REQUESTS="requests==2.5" # min version of requests library
 
-install: pip install $REQUESTS
+install: pip install $REQUESTS pytz
 
 script: python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 
 env:
  - REQUESTS="requests" # latest
- - REQUESTS="requests==2.5" # min version of requests library 
+ - REQUESTS="requests==2.5" # min version of requests library
 
 install: pip install $REQUESTS
 

--- a/castle/command.py
+++ b/castle/command.py
@@ -1,3 +1,4 @@
 from collections import namedtuple
 
+
 Command = namedtuple('Command', ['method', 'endpoint', 'data'])

--- a/castle/commands/authenticate.py
+++ b/castle/commands/authenticate.py
@@ -1,9 +1,11 @@
 from castle.command import Command
 from castle.commands.with_context import validate, WithContext
+from castle.utils import timestamp
 
 
 class CommandsAuthenticate(WithContext):
     def build(self, options):
         validate(options, 'event', 'user_id')
+        options.setdefault('sent_at', timestamp())
 
         return Command(method='post', endpoint='authenticate', data=self.build_context(options))

--- a/castle/commands/identify.py
+++ b/castle/commands/identify.py
@@ -1,11 +1,13 @@
 from castle.command import Command
 from castle.commands.with_context import validate, WithContext
 from castle.exceptions import InvalidParametersError
+from castle.utils import timestamp
 
 
 class CommandsIdentify(WithContext):
     def build(self, options):
         validate(options, 'user_id')
+        options.setdefault('sent_at', timestamp())
 
         if options.get('properties'):
             raise InvalidParametersError('properties are not supported in identify calls')

--- a/castle/commands/track.py
+++ b/castle/commands/track.py
@@ -1,9 +1,11 @@
 from castle.command import Command
 from castle.commands.with_context import validate, WithContext
+from castle.utils import timestamp
 
 
 class CommandsTrack(WithContext):
     def build(self, options):
         validate(options, 'event')
+        options.setdefault('sent_at', timestamp())
 
         return Command(method='post', endpoint='track', data=self.build_context(options))

--- a/castle/commands/with_context.py
+++ b/castle/commands/with_context.py
@@ -7,6 +7,7 @@ def validate(options, *args):
         if options.get(key) is None or options.get(key) == '':
             raise InvalidParametersError("{key} is missing or empty".format(key=key))
 
+
 def sanitize_active_mode(options):
     if 'active' in options.get('context', dict()):
         if not isinstance(options.get('context').get('active'), bool):

--- a/castle/configuration.py
+++ b/castle/configuration.py
@@ -1,6 +1,7 @@
 from castle.exceptions import FailoverStrategyValueError
 from castle.headers_formatter import HeadersFormatter
 
+
 WHITELISTED = [
     'User-Agent',
     'Accept-Language',
@@ -105,5 +106,6 @@ class Configuration(object):
             self.__failover_strategy = value
         else:
             raise FailoverStrategyValueError
+
 
 configuration = Configuration()

--- a/castle/context/default.py
+++ b/castle/context/default.py
@@ -4,7 +4,9 @@ from castle.extractors.client_id import ExtractorsClientId
 from castle.extractors.headers import ExtractorsHeaders
 from castle.extractors.ip import ExtractorsIp
 
+
 __version__ = VERSION
+
 
 class ContextDefault(object):
     def __init__(self, request, cookies):

--- a/castle/context/merger.py
+++ b/castle/context/merger.py
@@ -1,5 +1,6 @@
 from castle.utils import clone, deep_merge
 
+
 class ContextMerger(object):
     def __init__(self, source):
         self.source_copy = clone(source)

--- a/castle/exceptions.py
+++ b/castle/exceptions.py
@@ -2,31 +2,40 @@
 class CastleError(Exception):
     """Base class for all Castle errors."""
 
+
 # Raised when invalid failover strategy value passed
 class FailoverStrategyValueError(CastleError):
     pass
+
 
 # Raised when invalid parameter are passed
 class InvalidParametersError(CastleError):
     pass
 
+
 class BadRequestError(CastleError):
     pass
+
 
 class UnauthorizedError(CastleError):
     pass
 
+
 class ForbiddenError(CastleError):
     pass
+
 
 class NotFoundError(CastleError):
     pass
 
+
 class UserUnauthorizedError(CastleError):
     pass
 
+
 class ApiError(CastleError):
     pass
+
 
 class InternalServerError(CastleError):
     pass

--- a/castle/extractors/headers.py
+++ b/castle/extractors/headers.py
@@ -10,7 +10,7 @@ class ExtractorsHeaders(object):
     def call(self):
         headers = dict()
 
-        for key, value in self.environ.items():
+        for key, value in self.environ.iteritems():
             name = self.formatter.call(key)
             if name not in configuration.whitelisted:
                 continue

--- a/castle/headers_formatter.py
+++ b/castle/headers_formatter.py
@@ -1,5 +1,6 @@
 import re
 
+
 class HeadersFormatter(object):
     @staticmethod
     def call(header):

--- a/castle/response.py
+++ b/castle/response.py
@@ -1,6 +1,7 @@
 from castle.exceptions import BadRequestError, UnauthorizedError, ForbiddenError, NotFoundError, \
     UserUnauthorizedError, InvalidParametersError, ApiError, InternalServerError
 
+
 RESPONSE_ERRORS = {
     400: BadRequestError,
     401: UnauthorizedError,
@@ -9,6 +10,7 @@ RESPONSE_ERRORS = {
     419: UserUnauthorizedError,
     422: InvalidParametersError
 }
+
 
 class Response(object):
     def __init__(self, response):

--- a/castle/test/__init__.py
+++ b/castle/test/__init__.py
@@ -1,4 +1,3 @@
-import pkgutil
 import logging
 import sys
 
@@ -17,6 +16,7 @@ if sys.version_info[0] == 2:
     import mock
 else:
     from unittest import mock
+
 
 TEST_MODULES = [
     'castle.test.api_test',
@@ -40,6 +40,7 @@ TEST_MODULES = [
     'castle.test.utils_test',
     'castle.test.review_test'
 ]
+
 
 def all():
     logging.basicConfig(stream=sys.stderr)

--- a/castle/test/api_test.py
+++ b/castle/test/api_test.py
@@ -6,11 +6,14 @@ from castle.api import Api
 from castle.command import Command
 from castle.request import Request
 
+
 def command():
     return Command(method='post', endpoint='authenticate', data={})
 
+
 def response_text():
     return 'authenticate'
+
 
 class ApiTestCase(unittest.TestCase):
     def test_init(self):

--- a/castle/test/client_test.py
+++ b/castle/test/client_test.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+
 import responses
 
 from castle.test import unittest

--- a/castle/test/command_test.py
+++ b/castle/test/command_test.py
@@ -1,6 +1,7 @@
 from castle.test import unittest
 from castle.command import Command
 
+
 def command():
     return Command(
         method='post',

--- a/castle/test/commands/authenticate_test.py
+++ b/castle/test/commands/authenticate_test.py
@@ -8,6 +8,7 @@ from castle.exceptions import InvalidParametersError
 def default_payload():
     return {'event': '$login.authenticate', 'user_id': '1234'}
 
+
 class CommandsAuthenticateTestCase(unittest.TestCase):
     def test_init(self):
         self.assertIsInstance(CommandsAuthenticate({}).context_merger, ContextMerger)

--- a/castle/test/commands/identify_test.py
+++ b/castle/test/commands/identify_test.py
@@ -8,6 +8,7 @@ from castle.exceptions import InvalidParametersError
 def default_payload():
     return {'user_id': '1234'}
 
+
 class CommandsIdentifyTestCase(unittest.TestCase):
     def test_init(self):
         self.assertIsInstance(CommandsIdentify({}).context_merger, ContextMerger)

--- a/castle/test/commands/review_test.py
+++ b/castle/test/commands/review_test.py
@@ -7,6 +7,7 @@ from castle.exceptions import InvalidParametersError
 def review_id():
     return '1234'
 
+
 class CommandsReviewTestCase(unittest.TestCase):
     def test_build_no_review_id(self):
         with self.assertRaises(InvalidParametersError):

--- a/castle/test/commands/track_test.py
+++ b/castle/test/commands/track_test.py
@@ -8,6 +8,7 @@ from castle.exceptions import InvalidParametersError
 def default_payload():
     return {'event': '$login.authenticate'}
 
+
 class CommandsTrackTestCase(unittest.TestCase):
     def test_init(self):
         self.assertIsInstance(CommandsTrack({}).context_merger, ContextMerger)

--- a/castle/test/commands/track_test.py
+++ b/castle/test/commands/track_test.py
@@ -1,93 +1,75 @@
-from castle.test import unittest
+from castle.test import mock, unittest
 from castle.command import Command
 from castle.commands.track import CommandsTrack
 from castle.context.merger import ContextMerger
 from castle.exceptions import InvalidParametersError
+from castle.utils import clone
 
 
-def default_payload():
+def default_options():
+    """Default options include all required fields."""
     return {'event': '$login.authenticate'}
 
 
+def default_options_plus(**extra):
+    """Default options plus the given extra fields."""
+    options = default_options()
+    options.update(extra)
+    return options
+
+
+def default_command_with_data(**data):
+    """What we expect the authenticate command to look like."""
+    return Command(
+        method='post',
+        endpoint='track',
+        data=dict(sent_at=mock.sentinel.timestamp, **data)
+    )
+
+
 class CommandsTrackTestCase(unittest.TestCase):
+    def setUp(self):
+        # patch timestamp to return a known value
+        timestamp_patcher = mock.patch('castle.commands.track.timestamp')
+        self.mock_timestamp = timestamp_patcher.start()
+        self.mock_timestamp.return_value = mock.sentinel.timestamp
+        self.addCleanup(timestamp_patcher.stop)
+
     def test_init(self):
-        self.assertIsInstance(CommandsTrack({}).context_merger, ContextMerger)
+        obj = CommandsTrack({})
+        self.assertIsInstance(obj.context_merger, ContextMerger)
 
     def test_build(self):
-        payload = default_payload()
-        payload.update(context={'test': '1'})
-        command = CommandsTrack({}).build(payload)
-        self.assertIsInstance(command, Command)
-        self.assertEqual(command.method, 'post')
-        self.assertEqual(command.endpoint, 'track')
-        self.assertEqual(command.data, payload)
+        context = {'lang': 'es'}
+        options = default_options_plus(context={'local time': '8:53pm'})
+
+        # expect the original context to have been merged with the context specified in the options
+        expected_data = clone(options)
+        expected_data.update(context={'lang': 'es', 'local time': '8:53pm'})
+        expected = default_command_with_data(**expected_data)
+
+        self.assertEqual(CommandsTrack(context).build(options), expected)
 
     def test_build_no_event(self):
+        context = {}
+        options = default_options()
+        options.pop('event')
+
         with self.assertRaises(InvalidParametersError):
-            CommandsTrack({}).build({'user_id': '1234'})
+            CommandsTrack(context).build(options)
 
-    def test_build_user_id(self):
-        payload = default_payload()
-        payload.update(user_id='1234')
-        command_data = default_payload()
-        command_data.update(user_id='1234', context={})
-        command = CommandsTrack({}).build(payload)
-        self.assertIsInstance(command, Command)
-        self.assertEqual(command.method, 'post')
-        self.assertEqual(command.endpoint, 'track')
-        self.assertEqual(command.data, command_data)
+    def test_build_properties_allowed(self):
+        context = {}
+        options = default_options_plus(properties={'face': 'handsome'})
 
-    def test_build_properties(self):
-        payload = default_payload()
-        payload.update(properties={'test': '1'})
-        command_data = default_payload()
-        command_data.update(properties={'test': '1'}, context={})
-        command = CommandsTrack({}).build(payload)
-        self.assertIsInstance(command, Command)
-        self.assertEqual(command.method, 'post')
-        self.assertEqual(command.endpoint, 'track')
-        self.assertEqual(command.data, command_data)
+        expected = default_command_with_data(context=context, **options)
 
-    def test_build_traits(self):
-        payload = default_payload()
-        payload.update(traits={'test': '1'})
-        command_data = default_payload()
-        command_data.update(traits={'test': '1'}, context={})
-        command = CommandsTrack({}).build(payload)
-        self.assertIsInstance(command, Command)
-        self.assertEqual(command.method, 'post')
-        self.assertEqual(command.endpoint, 'track')
-        self.assertEqual(command.data, command_data)
+        self.assertEqual(CommandsTrack(context).build(options), expected)
 
-    def test_build_active_true(self):
-        payload = default_payload()
-        payload.update(context={'active': True})
-        command = CommandsTrack({}).build(payload)
-        self.assertIsInstance(command, Command)
-        self.assertEqual(command.method, 'post')
-        self.assertEqual(command.endpoint, 'track')
-        self.assertEqual(command.data, payload)
+    def test_build_traits_allowed(self):
+        context = {}
+        options = default_options_plus(traits={'email': 'track@all.the.things.com'})
 
-    def test_build_active_false(self):
-        payload = default_payload()
-        payload.update(context={'active': False})
-        command = CommandsTrack({}).build(payload)
-        self.assertIsInstance(command, Command)
-        self.assertEqual(command.method, 'post')
-        self.assertEqual(command.endpoint, 'track')
-        self.assertEqual(command.data, payload)
+        expected = default_command_with_data(context=context, **options)
 
-    def test_build_active_string(self):
-        payload = default_payload()
-        payload.update(context={'active': 'string'})
-        command_data = default_payload()
-        command_data.update(context={})
-        command = CommandsTrack({}).build(payload)
-        self.assertIsInstance(command, Command)
-        self.assertEqual(command.method, 'post')
-        self.assertEqual(command.endpoint, 'track')
-        self.assertEqual(command.data, command_data)
-
-    def test_build_context(self):
-        context = {'test': '1'}
-        self.assertEqual(CommandsTrack({}).build_context(context), context)
+        self.assertEqual(CommandsTrack(context).build(options), expected)

--- a/castle/test/commands/with_context_test.py
+++ b/castle/test/commands/with_context_test.py
@@ -1,0 +1,91 @@
+from castle.commands.with_context import sanitize_active_mode, WithContext
+from castle.test import mock, unittest
+
+
+class SanitizeActiveMode(unittest.TestCase):
+    def test_when_active_not_specified_then_options_unmodified(self):
+        options = {'context': {'whatever': 'okay'}, 'test': 'nonsense'}
+        sanitize_active_mode(options)
+
+        self.assertEqual(options, {'context': {'whatever': 'okay'}, 'test': 'nonsense'})
+
+    def test_when_active_true_then_options_unmodified(self):
+        options = {'context': {'active': True}, 'foo': 'spam'}
+        sanitize_active_mode(options)
+
+        self.assertEqual(options, {'context': {'active': True}, 'foo': 'spam'})
+
+    def test_when_active_false_then_options_unmodified(self):
+        options = {'context': {'active': False}, 'foo': 'spam'}
+        sanitize_active_mode(options)
+
+        self.assertEqual(options, {'context': {'active': False}, 'foo': 'spam'})
+
+    def test_when_active_string_then_active_removed(self):
+        options = {'context': {'active': 'true'}, 'foo': 'spam'}
+        sanitize_active_mode(options)
+
+        self.assertEqual(options, {'context': {}, 'foo': 'spam'})
+
+    def test_when_active_int_then_active_removed(self):
+        options = {'context': {'active': 1, 'another thing': 'sure'}, 'frog': 'spawn'}
+        sanitize_active_mode(options)
+
+        self.assertEqual(options, {'context': {'another thing': 'sure'}, 'frog': 'spawn'})
+
+
+class WithContextTestCase(unittest.TestCase):
+
+    @mock.patch('castle.commands.with_context.ContextMerger')
+    def test_init(self, mock_ContextMerger):
+        mock_ContextMerger.return_value = mock.sentinel.merger_instance
+
+        obj = WithContext(mock.sentinel.context)
+
+        self.assertIs(obj.context_merger, mock.sentinel.merger_instance)
+        mock_ContextMerger.assert_called_once_with(mock.sentinel.context)
+
+    def test_build_context(self):
+        context = {'thirsty': True}
+        options = {'context': {'hungry': True}, 'want': ['pizza', 'beer']}
+
+        # expect the original context to have been merged with the context specified in the options
+        expected = {'context': {'thirsty': True, 'hungry': True}, 'want': ['pizza', 'beer']}
+
+        self.assertEqual(WithContext(context).build_context(options), expected)
+
+    @mock.patch('castle.commands.with_context.sanitize_active_mode')
+    def test_build_context_sanitizes_active_mode_option(self, mock_sanitize_active_mode):
+        context = {}  # doesn't matter for this test
+        options = {'context': mock.sentinel.options_context}
+
+        obj = WithContext(context)
+        with mock.patch.object(obj, 'merge_context') as mock_merge_context:
+            obj.build_context(options)
+
+        mock_sanitize_active_mode.assert_called_once_with(options)
+        mock_merge_context.assert_called_once_with(mock.sentinel.options_context)
+
+    def test_build_context_empty_options(self):
+        context = {'ambiance': 'smokey'}
+        options = {}
+
+        expected = {'context': context}
+
+        self.assertEqual(WithContext(context).build_context(options), expected)
+
+    def test_build_context_override_value(self):
+        context = {'mood': 'grumpy', 'sky': 'blue', 'drink': 'none to speak of'}
+        options = {'context': {'mood': 'all smiles', 'drink': 3}}
+
+        expected = {'context': {'mood': 'all smiles', 'sky': 'blue', 'drink': 3}}
+
+        self.assertEqual(WithContext(context).build_context(options), expected)
+
+    def test_build_context_options_without_context(self):
+        context = {'sleepy': True}
+        options = {'giving up': False}
+
+        expected = {'context': {'sleepy': True}, 'giving up': False}
+
+        self.assertEqual(WithContext(context).build_context(options), expected)

--- a/castle/test/context/default_test.py
+++ b/castle/test/context/default_test.py
@@ -7,17 +7,21 @@ from castle.context.default import ContextDefault
 def client_id():
     return 'abcd'
 
+
 def cookies():
     return {'__cid': client_id()}
 
+
 def request_ip():
     return '127.0.0.1'
+
 
 def environ():
     return {
         'HTTP_X_FORWARDED_FOR': request_ip(),
         'HTTP_COOKIE': "__cid={client_id()};other=efgh"
     }
+
 
 def environ_with_extras():
     extra = {
@@ -28,11 +32,13 @@ def environ_with_extras():
     context.update(extra)
     return context
 
+
 def request(env):
     req = mock.Mock()
     req.ip = request_ip()
     req.environ = env
     return req
+
 
 class ContextDefaultTestCase(unittest.TestCase):
     def test_default_context(self):

--- a/castle/test/extractors/client_id_test.py
+++ b/castle/test/extractors/client_id_test.py
@@ -6,14 +6,18 @@ from castle.extractors.client_id import ExtractorsClientId
 def client_id():
     return 'cookies'
 
+
 def client_id_environ():
     return 'environ'
+
 
 def cookies():
     return {'__cid': client_id()}
 
+
 def environ():
     return {'HTTP_X_CASTLE_CLIENT_ID': client_id_environ()}
+
 
 class ExtractorsClientIdTestCase(unittest.TestCase):
     def test_extract_client_id_from_cookies(self):

--- a/castle/test/extractors/headers_test.py
+++ b/castle/test/extractors/headers_test.py
@@ -6,6 +6,7 @@ from castle.extractors.headers import ExtractorsHeaders
 def client_id():
     return 'abcd'
 
+
 def environ():
     return {
         'HTTP_X_FORWARDED_FOR': '1.2.3.4',
@@ -13,6 +14,7 @@ def environ():
         'TEST': '1',
         'HTTP_COOKIE': "__cid={client_id};other=efgh".format(client_id=client_id)
     }
+
 
 class ExtractorsHeadersTestCase(unittest.TestCase):
     def test_extract_headers(self):

--- a/castle/test/extractors/ip_test.py
+++ b/castle/test/extractors/ip_test.py
@@ -5,20 +5,24 @@ from castle.extractors.ip import ExtractorsIp
 def request_ip():
     return '127.0.0.1'
 
+
 def request():
     req = mock.Mock(spec=['ip'])
     req.ip = request_ip()
     return req
+
 
 def request_without_ip_remote_addr():
     req = mock.Mock(spec=['environ'])
     req.environ = {'REMOTE_ADDR': request_ip()}
     return req
 
+
 def request_without_ip_x_forwarded_for():
     req = mock.Mock(spec=['environ'])
     req.environ = {'HTTP_X_FORWARDED_FOR': request_ip()}
     return req
+
 
 class ExtractorsIpTestCase(unittest.TestCase):
     def test_extract_ip(self):

--- a/castle/test/failover_response_test.py
+++ b/castle/test/failover_response_test.py
@@ -2,8 +2,10 @@ from castle.test import unittest
 from castle.configuration import configuration
 from castle.failover_response import FailoverResponse
 
+
 def user_id():
     return '1234'
+
 
 def strategy():
     return 'deny'

--- a/castle/test/response_test.py
+++ b/castle/test/response_test.py
@@ -6,6 +6,7 @@ from castle.response import Response
 from castle.exceptions import BadRequestError, UnauthorizedError, ForbiddenError, NotFoundError, \
     UserUnauthorizedError, InvalidParametersError, InternalServerError
 
+
 def response(status_code=200, body=None):
     resp = requests.Response()
     resp.raw = io.BytesIO(body)
@@ -23,7 +24,7 @@ class ResponseTestCase(unittest.TestCase):
     def test_response_authenticate(self):
         self.assertEqual(
             Response(response(body=b'{"action":"allow","user_id":"12345"}')).call(),
-            {"action":"allow", "user_id":"12345"}
+            {"action": "allow", "user_id": "12345"}
         )
 
     def test_verify_200_299(self):

--- a/castle/test/utils_test.py
+++ b/castle/test/utils_test.py
@@ -1,5 +1,7 @@
-from castle.test import unittest
-from castle.utils import clone, deep_merge
+from datetime import datetime
+
+from castle.test import mock, unittest
+from castle.utils import clone, deep_merge, timestamp
 
 
 class UtilsTestCase(unittest.TestCase):
@@ -100,3 +102,12 @@ class DeepMergeTestCase(unittest.TestCase):
             }
         }
         self.assertEqual(a, expected)
+
+
+class TimestampTestCase(unittest.TestCase):
+
+    @mock.patch('castle.utils.datetime')
+    def test_it_should_use_iso_format(self, mock_datetime):
+        mock_datetime.utcnow.return_value = datetime(2018, 1, 2, 3, 4, 5, 678901)
+        expected = '2018-01-02T03:04:05.678901+00:00'
+        self.assertEqual(timestamp(), expected)

--- a/castle/test/utils_test.py
+++ b/castle/test/utils_test.py
@@ -9,6 +9,7 @@ class UtilsTestCase(unittest.TestCase):
         self.assertEqual(params, new_params)
         self.assertIsNot(new_params, params)
 
+
 class DeepMergeTestCase(unittest.TestCase):
     def test_simple_merge(self):
         a = {'key': 'value'}

--- a/castle/utils.py
+++ b/castle/utils.py
@@ -1,10 +1,14 @@
 import copy
 
+
 def clone(dict_object):
     return copy.deepcopy(dict_object)
 
+
 def deep_merge(base, extra):
-    """Deeply two dictionaries, overriding existing keys in the base.
+    """
+    Deeply merge two dictionaries, overriding existing keys in the base.
+
     :param base: The base dictionary which will be merged into.
     :param extra: The dictionary to merge into the base. Keys from this
         dictionary will take precedence.

--- a/castle/utils.py
+++ b/castle/utils.py
@@ -13,7 +13,7 @@ def deep_merge(base, extra):
     :param extra: The dictionary to merge into the base. Keys from this
         dictionary will take precedence.
     """
-    for key in extra:
+    for key in extra.iterkeys():
         # If the key represents a dict on both given dicts, merge the sub-dicts
         if key in base and isinstance(base[key], dict)\
                 and isinstance(extra[key], dict):

--- a/castle/utils.py
+++ b/castle/utils.py
@@ -1,4 +1,7 @@
 import copy
+from datetime import datetime
+
+import pytz
 
 
 def clone(dict_object):
@@ -22,3 +25,8 @@ def deep_merge(base, extra):
 
         # Otherwise, set the key on the base to be the value of the extra.
         base[key] = extra[key]
+
+
+def timestamp():
+    """Return an ISO8601 timestamp representing the current datetime in UTC."""
+    return datetime.utcnow().replace(tzinfo=pytz.UTC).isoformat()

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,10 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ],
-    install_requires=['requests>=2.5'],
+    install_requires=[
+        'pytz',  # pytz is generally backwards compatible
+        'requests>=2.5',
+    ],
     extras_require={
         'test': ['responses'],
     },

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,11 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     install_requires=['requests>=2.5'],
-    tests_require=['responses'],
+    extras_require={
+        'test': ['responses'],
+    },
+    # A better way to specify test requirements
+    # see https://github.com/pypa/pip/issues/1197#issuecomment-228939212
+    tests_require=['castle[test]'],
     test_suite='castle.test.all'
 )


### PR DESCRIPTION
# work in progress
Tests definitely gonna fail.

# Issue
https://github.com/castle/castle-python/issues/21

# What
Adding support for asynchronous tracking.

Implementation is based on what was done for the ruby client (https://github.com/castle/castle-ruby/)

## highlights
- Client constructor now takes `context` and `options` parameters, which are built with calls to `build_client_context` and `build_client_options`, respectively.
- You can still construct a Client with the old `request` and `options` parameters via the new classmethod `from_request`
- Automatically adds a timestamp property into the options for `authenticate`, `identify`, and `track` commands
- `authenticate`, `identify`, and `track` commands now also automatically add a `sent_at` timestamp property
- Introduced new dependency, `pytz`, which is the de-facto library for timezones.
    - I did not pin the version because I think we can safely assume it will remain backwards compatible.

# Misc changes
- removed a fair amount of lint
- refactored command tests (see commit remarks, if you're curious)
- minor change in how test dependencies are specified in `setup.py`
    - makes it easier to install test deps with pip