### PR TITLE
feat: Add connection pooling through shared singleton

### DIFF
--- a/castle/request.py
+++ b/castle/request.py
@@ -1,15 +1,16 @@
 import json
-import requests
 from castle.configuration import configuration
+from castle.session import SessionSharer
 
 
 class Request(object):
     def __init__(self, headers=None):
         self.headers = headers or dict()
         self.base_url = Request.build_base_url()
+        self.sharer = SessionSharer()
 
     def build_query(self, method, path, params):
-        return requests.request(
+        return self.sharer.session.request(
             method,
             self.build_url(path),
             auth=('', configuration.api_secret),

--- a/castle/session.py
+++ b/castle/session.py
@@ -1,0 +1,16 @@
+import requests
+
+
+class SessionSharer(object):
+    class __SessionSharer:
+        def __init__(self):
+            self.session = requests.Session()
+    instance = None
+
+    def __new__(cls):
+        if not SessionSharer.instance:
+            SessionSharer.instance = SessionSharer.__SessionSharer()
+        return SessionSharer.instance
+
+    def __getattr__(self, name):
+        return getattr(self.instance, name)

--- a/castle/test/__init__.py
+++ b/castle/test/__init__.py
@@ -45,6 +45,7 @@ TEST_MODULES = [
     'castle.test.response_test',
     'castle.test.review_test',
     'castle.test.secure_mode_test',
+    'castle.test.session_test',
     'castle.test.validators.not_supported_test',
     'castle.test.validators.present_test',
     'castle.test.utils_test'

--- a/castle/test/request_test.py
+++ b/castle/test/request_test.py
@@ -1,8 +1,32 @@
+import sys
+import threading
 from requests import Response
 import responses
 from castle.test import unittest
 from castle.request import Request
 from castle.configuration import configuration
+
+try:
+    from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+except ImportError:
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+
+def run_server():
+    class SimpleHandler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            body = '{"action":"allow", "user_id": "123"}'.encode()
+            self.send_response(201)
+            self.send_header('content-type', 'application/json')
+            self.send_header('content-length', len(body))
+            self.end_headers()
+            self.wfile.write(body)
+
+
+    server = HTTPServer(('', 65521), SimpleHandler)
+    httpd_thread = threading.Thread(target=server.serve_forever)
+    httpd_thread.setDaemon(True)
+    httpd_thread.start()
+    return httpd_thread
 
 
 class RequestTestCase(unittest.TestCase):
@@ -29,7 +53,21 @@ class RequestTestCase(unittest.TestCase):
         self.assertIsInstance(res, Response)
         self.assertEqual(res.status_code, 200)
         self.assertEqual(res.json(), response_text)
+
         configuration.api_secret = None
+
+    def test_connection_pooled(self):
+        configuration.host = 'localhost'
+        configuration.port = 65521
+        run_server()
+        request = Request()
+        data = {'event': '$login.authenticate', 'user_id': '12345'}
+        response = request.build_query('post', 'authenticate', data)
+        num_pools = len(response.connection.poolmanager.pools.keys())
+        configuration.host = 'api.castle.io'
+        configuration.port = 443
+        self.assertEqual(num_pools, 1)
+
 
     def test_build_url(self):
         self.assertEqual(

--- a/castle/test/session_test.py
+++ b/castle/test/session_test.py
@@ -1,0 +1,21 @@
+from collections import namedtuple
+from castle.test import unittest
+from castle.client import Client
+
+
+def request():
+    req = namedtuple('Request', ['ip', 'environ', 'COOKIES'])
+    req.ip = '217.144.192.112'
+    req.environ = {'HTTP_X_FORWARDED_FOR': '217.144.192.112',
+                   'HTTP-User-Agent': 'test',
+                   'HTTP_X_CASTLE_CLIENT_ID': '1234'}
+    req.COOKIES = {}
+    return req
+
+
+class SessionTestCase(unittest.TestCase):
+    def test_init(self):
+        client = Client.from_request(request(), {})
+        client2 = Client.from_request(request(), {})
+        self.assertNotEqual(client.api.request, client2.api.request)
+        self.assertEqual(client.api.req.sharer, client2.api.req.sharer)


### PR DESCRIPTION
Uses the `requests.Sesson` built in connection pool and shares it across instances using a singleton.

Fixes #19 