### PR TITLE
Update whitelisting and blacklisting behavior

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ import and configure the library with your Castle API secret.
 
 .. code:: python
 
-    from castle.configuration import configuration, WHITE_LIST
+    from castle.configuration import configuration, WHITELISTED
 
     # Same as setting it through Castle.api_secret
     configuration.api_secret = ':YOUR-API-SECRET'
@@ -35,13 +35,13 @@ import and configure the library with your Castle API secret.
     # Whitelisted and Blacklisted headers are case insensitive and allow to use _ and - as a separator, http prefixes are removed
     # By default all headers are passed, but some are automatically scrubbed.
     # If you need to apply a whitelist, we recommend using the minimum set of
-    # standard headers that we've exposed in the `WHITE_LIST` constant.
+    # standard headers that we've exposed in the `WHITELISTED` constant.
     # Whitelisted headers
-    configuration.white_list = WHITE_LIST + ['X_HEADER']
+    configuration.whitelisted = WHITELISTED + ['X_HEADER']
 
-    # Blacklisted headers take advantage over white_list elements. Note that
+    # Blacklisted headers take advantage over whitelisted elements. Note that
     # some headers are always scrubbed, for security reasons.
-    configuration.black_list = ['HTTP-X-header']
+    configuration.blacklisted = ['HTTP-X-header']
 
 Tracking
 --------

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ import and configure the library with your Castle API secret.
 
 .. code:: python
 
-    from castle.configuration import configuration
+    from castle.configuration import configuration, WHITE_LIST
 
     # Same as setting it through Castle.api_secret
     configuration.api_secret = ':YOUR-API-SECRET'
@@ -33,15 +33,15 @@ import and configure the library with your Castle API secret.
     configuration.request_timeout = 1000
 
     # Whitelisted and Blacklisted headers are case insensitive and allow to use _ and - as a separator, http prefixes are removed
+    # By default all headers are passed, but some are automatically scrubbed.
+    # If you need to apply a whitelist, we recommend using the minimum set of
+    # standard headers that we've exposed in the `WHITE_LIST` constant.
     # Whitelisted headers
-    configuration.whitelisted = ['X_HEADER']
-    # or append to default
-    configuration.whitelisted = configuration.whitelisted + ['http-x-header']
+    configuration.white_list = WHITE_LIST + ['X_HEADER']
 
-    # Blacklisted headers take advantage over whitelisted elements
-    configuration.blacklisted = ['HTTP-X-header']
-    # or append to default
-    configuration.blacklisted = configuration.blacklisted + ['X_HEADER']
+    # Blacklisted headers take advantage over white_list elements. Note that
+    # some headers are always scrubbed, for security reasons.
+    configuration.black_list = ['HTTP-X-header']
 
 Tracking
 --------

--- a/castle/configuration.py
+++ b/castle/configuration.py
@@ -1,22 +1,25 @@
 from castle.exceptions import ConfigurationError
 from castle.headers_formatter import HeadersFormatter
 
-WHITELISTED = [
-    'User-Agent',
-    'Accept-Language',
-    'Accept-Encoding',
-    'Accept-Charset',
-    'Accept',
-    'Accept-Datetime',
-    'Forwarded',
-    'X-Forwarded',
-    'X-Real-IP',
-    'REMOTE_ADDR',
-    'X-Forwarded-For',
-    'CF_CONNECTING_IP'
-]
-
 BLACKLISTED = ['HTTP_COOKIE']
+
+WHITELISTED = [
+    "Accept",
+    "Accept-Charset",
+    "Accept-Datetime",
+    "Accept-Encoding",
+    "Accept-Language",
+    "Cache-Control",
+    "Connection",
+    "Content-Length",
+    "Content-Type",
+    "Cookie",
+    "Host",
+    "Origin",
+    "Pragma",
+    "Referer",
+    "User-Agent",
+]
 
 # 500 milliseconds
 REQUEST_TIMEOUT = 500
@@ -29,7 +32,7 @@ class Configuration(object):
         self.host = 'api.castle.io'
         self.port = 443
         self.url_prefix = '/v1'
-        self.whitelisted = WHITELISTED
+        self.whitelisted = []
         self.blacklisted = BLACKLISTED
         self.request_timeout = REQUEST_TIMEOUT
         self.failover_strategy = 'allow'

--- a/castle/configuration.py
+++ b/castle/configuration.py
@@ -33,7 +33,7 @@ class Configuration(object):
         self.port = 443
         self.url_prefix = '/v1'
         self.white_list = []
-        self.black_list = BLACK_LIST
+        self.black_list = []
         self.request_timeout = REQUEST_TIMEOUT
         self.failover_strategy = 'allow'
 

--- a/castle/configuration.py
+++ b/castle/configuration.py
@@ -1,7 +1,7 @@
 from castle.exceptions import ConfigurationError
 from castle.headers_formatter import HeadersFormatter
 
-BLACK_LIST = ['HTTP_COOKIE', 'HTTP_AUTHORIZATION']
+BLACK_LIST = ['Cookie', 'Authorization']
 
 WHITE_LIST = [
     "Accept",

--- a/castle/configuration.py
+++ b/castle/configuration.py
@@ -87,9 +87,9 @@ class Configuration(object):
     @black_list.setter
     def black_list(self, value):
         if value:
-            self.__black_list = [HeadersFormatter.call(v) for v in value] + BLACK_LIST
+            self.__black_list = [HeadersFormatter.call(v) for v in value]
         else:
-            self.__black_list = BLACK_LIST
+            self.__black_list = []
 
     @property
     def request_timeout(self):

--- a/castle/configuration.py
+++ b/castle/configuration.py
@@ -16,7 +16,10 @@ WHITELISTED = [
     "Origin",
     "Pragma",
     "Referer",
+    "TE",
+    "Upgrade-Insecure-Requests",
     "User-Agent",
+    "X-Castle-Client-Id",
 ]
 
 # 500 milliseconds

--- a/castle/configuration.py
+++ b/castle/configuration.py
@@ -1,9 +1,9 @@
 from castle.exceptions import ConfigurationError
 from castle.headers_formatter import HeadersFormatter
 
-BLACKLISTED = ['HTTP_COOKIE']
+BLACK_LIST = ['HTTP_COOKIE', 'HTTP_AUTHORIZATION']
 
-WHITELISTED = [
+WHITE_LIST = [
     "Accept",
     "Accept-Charset",
     "Accept-Datetime",
@@ -32,8 +32,8 @@ class Configuration(object):
         self.host = 'api.castle.io'
         self.port = 443
         self.url_prefix = '/v1'
-        self.whitelisted = []
-        self.blacklisted = BLACKLISTED
+        self.white_list = []
+        self.black_list = BLACK_LIST
         self.request_timeout = REQUEST_TIMEOUT
         self.failover_strategy = 'allow'
 
@@ -70,26 +70,26 @@ class Configuration(object):
         self.__url_prefix = value
 
     @property
-    def whitelisted(self):
-        return self.__whitelisted
+    def white_list(self):
+        return self.__white_list
 
-    @whitelisted.setter
-    def whitelisted(self, value):
+    @white_list.setter
+    def white_list(self, value):
         if value:
-            self.__whitelisted = [HeadersFormatter.call(v) for v in value]
+            self.__white_list = [HeadersFormatter.call(v) for v in value]
         else:
-            self.__whitelisted = []
+            self.__white_list = []
 
     @property
-    def blacklisted(self):
-        return self.__blacklisted
+    def black_list(self):
+        return self.__black_list
 
-    @blacklisted.setter
-    def blacklisted(self, value):
+    @black_list.setter
+    def black_list(self, value):
         if value:
-            self.__blacklisted = [HeadersFormatter.call(v) for v in value]
+            self.__black_list = [HeadersFormatter.call(v) for v in value] + BLACK_LIST
         else:
-            self.__blacklisted = []
+            self.__black_list = BLACK_LIST
 
     @property
     def request_timeout(self):

--- a/castle/configuration.py
+++ b/castle/configuration.py
@@ -1,9 +1,7 @@
 from castle.exceptions import ConfigurationError
 from castle.headers_formatter import HeadersFormatter
 
-BLACK_LIST = ['Cookie', 'Authorization']
-
-WHITE_LIST = [
+WHITELISTED = [
     "Accept",
     "Accept-Charset",
     "Accept-Datetime",
@@ -32,8 +30,8 @@ class Configuration(object):
         self.host = 'api.castle.io'
         self.port = 443
         self.url_prefix = '/v1'
-        self.white_list = []
-        self.black_list = []
+        self.whitelisted = []
+        self.blacklisted = []
         self.request_timeout = REQUEST_TIMEOUT
         self.failover_strategy = 'allow'
 
@@ -70,26 +68,26 @@ class Configuration(object):
         self.__url_prefix = value
 
     @property
-    def white_list(self):
-        return self.__white_list
+    def whitelisted(self):
+        return self.__whitelisted
 
-    @white_list.setter
-    def white_list(self, value):
+    @whitelisted.setter
+    def whitelisted(self, value):
         if value:
-            self.__white_list = [HeadersFormatter.call(v) for v in value]
+            self.__whitelisted = [HeadersFormatter.call(v) for v in value]
         else:
-            self.__white_list = []
+            self.__whitelisted = []
 
     @property
-    def black_list(self):
-        return self.__black_list
+    def blacklisted(self):
+        return self.__blacklisted
 
-    @black_list.setter
-    def black_list(self, value):
+    @blacklisted.setter
+    def blacklisted(self, value):
         if value:
-            self.__black_list = [HeadersFormatter.call(v) for v in value]
+            self.__blacklisted = [HeadersFormatter.call(v) for v in value]
         else:
-            self.__black_list = []
+            self.__blacklisted = []
 
     @property
     def request_timeout(self):

--- a/castle/extractors/headers.py
+++ b/castle/extractors/headers.py
@@ -1,5 +1,7 @@
 from castle.headers_formatter import HeadersFormatter
-from castle.configuration import configuration, BLACK_LIST
+from castle.configuration import configuration
+
+BLACKLISTED = ['Cookie', 'Authorization']
 
 
 class ExtractorsHeaders(object):
@@ -9,15 +11,15 @@ class ExtractorsHeaders(object):
 
     def call(self):
         headers = dict()
-        has_whitelist = len(configuration.white_list) > 0
-        extended_black_list = configuration.black_list + BLACK_LIST
+        has_whitelist = len(configuration.whitelisted) > 0
+        extended_blacklisted = configuration.blacklisted + BLACKLISTED
 
         for key, value in self.environ.items():
             name = self.formatter.call(key)
-            if has_whitelist and name not in configuration.white_list:
+            if has_whitelist and name not in configuration.whitelisted:
                 headers[name] = True
                 continue
-            if name in extended_black_list:
+            if name in extended_blacklisted:
                 headers[name] = True
                 continue
             headers[name] = value

--- a/castle/extractors/headers.py
+++ b/castle/extractors/headers.py
@@ -9,13 +9,13 @@ class ExtractorsHeaders(object):
 
     def call(self):
         headers = dict()
-        has_whitelist = len(configuration.whitelisted) > 0
+        has_whitelist = len(configuration.white_list) > 0
 
         for key, value in self.environ.items():
             name = self.formatter.call(key)
-            if has_whitelist and name not in configuration.whitelisted:
+            if has_whitelist and name not in configuration.white_list:
                 continue
-            if name in configuration.blacklisted:
+            if name in configuration.black_list:
                 continue
             headers[name] = value
 

--- a/castle/extractors/headers.py
+++ b/castle/extractors/headers.py
@@ -9,10 +9,11 @@ class ExtractorsHeaders(object):
 
     def call(self):
         headers = dict()
+        has_whitelist = len(configuration.whitelisted) > 0
 
         for key, value in self.environ.items():
             name = self.formatter.call(key)
-            if name not in configuration.whitelisted:
+            if has_whitelist and name not in configuration.whitelisted:
                 continue
             if name in configuration.blacklisted:
                 continue

--- a/castle/extractors/headers.py
+++ b/castle/extractors/headers.py
@@ -1,5 +1,5 @@
 from castle.headers_formatter import HeadersFormatter
-from castle.configuration import configuration
+from castle.configuration import configuration, BLACK_LIST
 
 
 class ExtractorsHeaders(object):
@@ -10,12 +10,15 @@ class ExtractorsHeaders(object):
     def call(self):
         headers = dict()
         has_whitelist = len(configuration.white_list) > 0
+        extended_black_list = configuration.black_list + BLACK_LIST
 
         for key, value in self.environ.items():
             name = self.formatter.call(key)
             if has_whitelist and name not in configuration.white_list:
+                headers[name] = True
                 continue
-            if name in configuration.black_list:
+            if name in extended_black_list:
+                headers[name] = True
                 continue
             headers[name] = value
 

--- a/castle/extractors/headers.py
+++ b/castle/extractors/headers.py
@@ -1,7 +1,8 @@
 from castle.headers_formatter import HeadersFormatter
 from castle.configuration import configuration
 
-BLACKLISTED = ['Cookie', 'Authorization']
+DEFAULT_BLACKLIST = ['Cookie', 'Authorization']
+DEFAULT_WHITELIST = ['User-Agent']
 
 
 class ExtractorsHeaders(object):
@@ -12,14 +13,13 @@ class ExtractorsHeaders(object):
     def call(self):
         headers = dict()
         has_whitelist = len(configuration.whitelisted) > 0
-        extended_blacklisted = configuration.blacklisted + BLACKLISTED
 
         for key, value in self.environ.items():
             name = self.formatter.call(key)
-            if has_whitelist and name not in configuration.whitelisted:
+            if has_whitelist and name not in configuration.whitelisted and name not in DEFAULT_WHITELIST:
                 headers[name] = True
                 continue
-            if name in extended_blacklisted:
+            if name in configuration.blacklisted or name in DEFAULT_BLACKLIST:
                 headers[name] = True
                 continue
             headers[name] = value

--- a/castle/test/client_test.py
+++ b/castle/test/client_test.py
@@ -31,7 +31,11 @@ class ClientTestCase(unittest.TestCase):
         context = {
             'active': True,
             'client_id': '1234',
-            'headers': {'User-Agent': 'test', 'X-Forwarded-For': '217.144.192.112'},
+            'headers': {
+                'User-Agent': 'test',
+                'X-Forwarded-For': '217.144.192.112',
+                'X-Castle-Client-Id': '1234'
+            },
             'ip': '217.144.192.112',
             'library': {'name': 'castle-python', 'version': VERSION},
             'origin': 'web',
@@ -189,7 +193,11 @@ class ClientTestCase(unittest.TestCase):
         context = {
             'active': True,
             'client_id': '1234',
-            'headers': {'User-Agent': 'test', 'X-Forwarded-For': '217.144.192.112'},
+            'headers': {
+                'User-Agent': 'test',
+                'X-Forwarded-For': '217.144.192.112',
+                'X-Castle-Client-Id': '1234'
+            },
             'ip': '217.144.192.112',
             'library': {'name': 'castle-python', 'version': VERSION},
             'origin': 'web',

--- a/castle/test/configuration_test.py
+++ b/castle/test/configuration_test.py
@@ -1,6 +1,6 @@
 from castle.test import unittest
 from castle.exceptions import ConfigurationError
-from castle.configuration import Configuration, WHITE_LIST, BLACK_LIST
+from castle.configuration import Configuration, BLACK_LIST
 from castle.headers_formatter import HeadersFormatter
 
 

--- a/castle/test/configuration_test.py
+++ b/castle/test/configuration_test.py
@@ -1,6 +1,6 @@
 from castle.test import unittest
 from castle.exceptions import ConfigurationError
-from castle.configuration import Configuration, BLACK_LIST
+from castle.configuration import Configuration
 from castle.headers_formatter import HeadersFormatter
 
 
@@ -11,8 +11,8 @@ class ConfigurationTestCase(unittest.TestCase):
         self.assertEqual(config.host, 'api.castle.io')
         self.assertEqual(config.port, 443)
         self.assertEqual(config.url_prefix, '/v1')
-        self.assertEqual(config.white_list, [])
-        self.assertEqual(config.black_list, [])
+        self.assertEqual(config.whitelisted, [])
+        self.assertEqual(config.blacklisted, [])
         self.assertEqual(config.request_timeout, 500)
         self.assertEqual(config.failover_strategy, 'allow')
 
@@ -36,35 +36,35 @@ class ConfigurationTestCase(unittest.TestCase):
         config.url_prefix = '/v2'
         self.assertEqual(config.url_prefix, '/v2')
 
-    def test_white_list_setter_list(self):
+    def test_whitelisted_setter_list(self):
         config = Configuration()
-        config.white_list = ['test']
-        self.assertEqual(config.white_list, ['Test'])
+        config.whitelisted = ['test']
+        self.assertEqual(config.whitelisted, ['Test'])
 
-    def test_white_list_setter_none(self):
+    def test_whitelisted_setter_none(self):
         config = Configuration()
-        config.white_list = None
-        self.assertEqual(config.white_list, [])
+        config.whitelisted = None
+        self.assertEqual(config.whitelisted, [])
 
-    def test_white_list_setter_empty(self):
+    def test_whitelisted_setter_empty(self):
         config = Configuration()
-        config.white_list = ''
-        self.assertEqual(config.white_list, [])
+        config.whitelisted = ''
+        self.assertEqual(config.whitelisted, [])
 
-    def test_black_list_setter_list(self):
+    def test_blacklisted_setter_list(self):
         config = Configuration()
-        config.black_list = ['test']
-        self.assertEqual(config.black_list, ['Test'])
+        config.blacklisted = ['test']
+        self.assertEqual(config.blacklisted, ['Test'])
 
-    def test_black_list_setter_none(self):
+    def test_blacklisted_setter_none(self):
         config = Configuration()
-        config.black_list = None
-        self.assertEqual(config.black_list, [])
+        config.blacklisted = None
+        self.assertEqual(config.blacklisted, [])
 
-    def test_black_list_setter_empty(self):
+    def test_blacklisted_setter_empty(self):
         config = Configuration()
-        config.black_list = ''
-        self.assertEqual(config.black_list, [])
+        config.blacklisted = ''
+        self.assertEqual(config.blacklisted, [])
 
     def test_request_timeout_setter(self):
         config = Configuration()

--- a/castle/test/configuration_test.py
+++ b/castle/test/configuration_test.py
@@ -11,8 +11,7 @@ class ConfigurationTestCase(unittest.TestCase):
         self.assertEqual(config.host, 'api.castle.io')
         self.assertEqual(config.port, 443)
         self.assertEqual(config.url_prefix, '/v1')
-        self.assertEqual(config.whitelisted, [
-                         HeadersFormatter.call(v) for v in WHITELISTED])
+        self.assertEqual(config.whitelisted, [])
         self.assertEqual(config.blacklisted, [
                          HeadersFormatter.call(v) for v in BLACKLISTED])
         self.assertEqual(config.request_timeout, 500)

--- a/castle/test/configuration_test.py
+++ b/castle/test/configuration_test.py
@@ -12,8 +12,7 @@ class ConfigurationTestCase(unittest.TestCase):
         self.assertEqual(config.port, 443)
         self.assertEqual(config.url_prefix, '/v1')
         self.assertEqual(config.white_list, [])
-        self.assertEqual(config.black_list, [
-                         HeadersFormatter.call(v) for v in BLACK_LIST])
+        self.assertEqual(config.black_list, [])
         self.assertEqual(config.request_timeout, 500)
         self.assertEqual(config.failover_strategy, 'allow')
 

--- a/castle/test/configuration_test.py
+++ b/castle/test/configuration_test.py
@@ -1,6 +1,6 @@
 from castle.test import unittest
 from castle.exceptions import ConfigurationError
-from castle.configuration import Configuration, WHITELISTED, BLACKLISTED
+from castle.configuration import Configuration, WHITE_LIST, BLACK_LIST
 from castle.headers_formatter import HeadersFormatter
 
 
@@ -11,9 +11,9 @@ class ConfigurationTestCase(unittest.TestCase):
         self.assertEqual(config.host, 'api.castle.io')
         self.assertEqual(config.port, 443)
         self.assertEqual(config.url_prefix, '/v1')
-        self.assertEqual(config.whitelisted, [])
-        self.assertEqual(config.blacklisted, [
-                         HeadersFormatter.call(v) for v in BLACKLISTED])
+        self.assertEqual(config.white_list, [])
+        self.assertEqual(config.black_list, [
+                         HeadersFormatter.call(v) for v in BLACK_LIST])
         self.assertEqual(config.request_timeout, 500)
         self.assertEqual(config.failover_strategy, 'allow')
 
@@ -37,35 +37,35 @@ class ConfigurationTestCase(unittest.TestCase):
         config.url_prefix = '/v2'
         self.assertEqual(config.url_prefix, '/v2')
 
-    def test_whitelisted_setter_list(self):
+    def test_white_list_setter_list(self):
         config = Configuration()
-        config.whitelisted = ['test']
-        self.assertEqual(config.whitelisted, ['Test'])
+        config.white_list = ['test']
+        self.assertEqual(config.white_list, ['Test'])
 
-    def test_whitelisted_setter_none(self):
+    def test_white_list_setter_none(self):
         config = Configuration()
-        config.whitelisted = None
-        self.assertEqual(config.whitelisted, [])
+        config.white_list = None
+        self.assertEqual(config.white_list, [])
 
-    def test_whitelisted_setter_empty(self):
+    def test_white_list_setter_empty(self):
         config = Configuration()
-        config.whitelisted = ''
-        self.assertEqual(config.whitelisted, [])
+        config.white_list = ''
+        self.assertEqual(config.white_list, [])
 
-    def test_blacklisted_setter_list(self):
+    def test_black_list_setter_list(self):
         config = Configuration()
-        config.blacklisted = ['test']
-        self.assertEqual(config.blacklisted, ['Test'])
+        config.black_list = ['test']
+        self.assertEqual(config.black_list, ['Test'])
 
-    def test_blacklisted_setter_none(self):
+    def test_black_list_setter_none(self):
         config = Configuration()
-        config.blacklisted = None
-        self.assertEqual(config.blacklisted, [])
+        config.black_list = None
+        self.assertEqual(config.black_list, [])
 
-    def test_blacklisted_setter_empty(self):
+    def test_black_list_setter_empty(self):
         config = Configuration()
-        config.blacklisted = ''
-        self.assertEqual(config.blacklisted, [])
+        config.black_list = ''
+        self.assertEqual(config.black_list, [])
 
     def test_request_timeout_setter(self):
         config = Configuration()

--- a/castle/test/context/default_test.py
+++ b/castle/test/context/default_test.py
@@ -46,7 +46,7 @@ class ContextDefaultTestCase(unittest.TestCase):
         self.assertEqual(context['client_id'], client_id())
         self.assertEqual(context['active'], True)
         self.assertEqual(context['origin'], 'web')
-        self.assertEqual(context['headers'], {'X-Forwarded-For': request_ip()})
+        self.assertEqual(context['headers'], {'X-Forwarded-For': request_ip(), 'Cookie': True})
         self.assertEqual(context['ip'], request_ip())
         self.assertDictEqual(context['library'], {
                              'name': 'castle-python', 'version': __version__})
@@ -59,8 +59,12 @@ class ContextDefaultTestCase(unittest.TestCase):
         self.assertEqual(context['origin'], 'web')
         self.assertEqual(
             context['headers'],
-            {'X-Forwarded-For': request_ip(), 'Accept-Language': 'en',
-             'User-Agent': 'test'}
+            {
+                'X-Forwarded-For': request_ip(),
+                'Accept-Language': 'en',
+                'User-Agent': 'test',
+                'Cookie': True
+            }
         )
         self.assertEqual(context['ip'], request_ip())
         self.assertDictEqual(

--- a/castle/test/extractors/headers_test.py
+++ b/castle/test/extractors/headers_test.py
@@ -18,13 +18,14 @@ def environ():
 
 class ExtractorsHeadersTestCase(unittest.TestCase):
     def test_extract_headers(self):
+        configuration.white_list = []
         self.assertEqual(ExtractorsHeaders(environ()).call(),
-                         {'User-Agent': 'requests', 'Ok': 'OK', 'Test': '1'})
+                         {'User-Agent': 'requests', 'Ok': 'OK', 'Test': '1', 'Cookie': True})
 
     def test_add_white_list_headers(self):
         configuration.white_list = WHITE_LIST + ['TEST']
         self.assertEqual(
             ExtractorsHeaders(environ()).call(),
-            {'User-Agent': 'requests', 'Test': '1'}
+            {'User-Agent': 'requests', 'Test': '1', 'Cookie': True, 'Ok': True}
         )
         configuration.white_list = []

--- a/castle/test/extractors/headers_test.py
+++ b/castle/test/extractors/headers_test.py
@@ -1,5 +1,5 @@
 from castle.test import unittest
-from castle.configuration import configuration, WHITELISTED
+from castle.configuration import configuration, WHITE_LIST
 from castle.extractors.headers import ExtractorsHeaders
 
 
@@ -21,10 +21,10 @@ class ExtractorsHeadersTestCase(unittest.TestCase):
         self.assertEqual(ExtractorsHeaders(environ()).call(),
                          {'User-Agent': 'requests', 'Ok': 'OK', 'Test': '1'})
 
-    def test_add_whitelisted_headers(self):
-        configuration.whitelisted = WHITELISTED + ['TEST']
+    def test_add_white_list_headers(self):
+        configuration.white_list = WHITE_LIST + ['TEST']
         self.assertEqual(
             ExtractorsHeaders(environ()).call(),
             {'User-Agent': 'requests', 'Test': '1'}
         )
-        configuration.whitelisted = []
+        configuration.white_list = []

--- a/castle/test/extractors/headers_test.py
+++ b/castle/test/extractors/headers_test.py
@@ -1,5 +1,5 @@
 from castle.test import unittest
-from castle.configuration import configuration
+from castle.configuration import configuration, WHITELISTED
 from castle.extractors.headers import ExtractorsHeaders
 
 
@@ -19,12 +19,12 @@ def environ():
 class ExtractorsHeadersTestCase(unittest.TestCase):
     def test_extract_headers(self):
         self.assertEqual(ExtractorsHeaders(environ()).call(),
-                         {'Test': '1', 'User-Agent': 'requests'})
+                         {'User-Agent': 'requests', 'Ok': 'OK', 'Test': '1'})
 
     def test_add_whitelisted_headers(self):
-        configuration.whitelisted += ['TEST']
+        configuration.whitelisted = WHITELISTED + ['TEST']
         self.assertEqual(
             ExtractorsHeaders(environ()).call(),
             {'User-Agent': 'requests', 'Test': '1'}
         )
-        configuration.whitelisted.remove('Test')
+        configuration.whitelisted = []

--- a/castle/test/extractors/headers_test.py
+++ b/castle/test/extractors/headers_test.py
@@ -1,5 +1,5 @@
 from castle.test import unittest
-from castle.configuration import configuration, WHITE_LIST
+from castle.configuration import configuration, WHITELISTED
 from castle.extractors.headers import ExtractorsHeaders
 
 
@@ -18,14 +18,14 @@ def environ():
 
 class ExtractorsHeadersTestCase(unittest.TestCase):
     def test_extract_headers(self):
-        configuration.white_list = []
+        configuration.whitelisted = []
         self.assertEqual(ExtractorsHeaders(environ()).call(),
                          {'User-Agent': 'requests', 'Ok': 'OK', 'Test': '1', 'Cookie': True})
 
-    def test_add_white_list_headers(self):
-        configuration.white_list = WHITE_LIST + ['TEST']
+    def test_add_whitelisted_headers(self):
+        configuration.whitelisted = WHITELISTED + ['TEST']
         self.assertEqual(
             ExtractorsHeaders(environ()).call(),
             {'User-Agent': 'requests', 'Test': '1', 'Cookie': True, 'Ok': True}
         )
-        configuration.white_list = []
+        configuration.whitelisted = []

--- a/castle/test/extractors/headers_test.py
+++ b/castle/test/extractors/headers_test.py
@@ -9,7 +9,7 @@ def client_id():
 
 def environ():
     return {
-        'HTTP_X_FORWARDED_FOR': '1.2.3.4',
+        'HTTP_USER_AGENT': 'requests',
         'HTTP_OK': 'OK',
         'TEST': '1',
         'HTTP_COOKIE': "__cid={client_id};other=efgh".format(client_id=client_id)
@@ -19,12 +19,12 @@ def environ():
 class ExtractorsHeadersTestCase(unittest.TestCase):
     def test_extract_headers(self):
         self.assertEqual(ExtractorsHeaders(environ()).call(),
-                         {'X-Forwarded-For': '1.2.3.4'})
+                         {'Test': '1', 'User-Agent': 'requests'})
 
-    def test_extend_whitelisted_headers(self):
+    def test_add_whitelisted_headers(self):
         configuration.whitelisted += ['TEST']
         self.assertEqual(
             ExtractorsHeaders(environ()).call(),
-            {'X-Forwarded-For': '1.2.3.4', 'Test': '1'}
+            {'User-Agent': 'requests', 'Test': '1'}
         )
         configuration.whitelisted.remove('Test')


### PR DESCRIPTION
To avoid dropping useful header names this updates the SDK to allow headers by default, and that headers are scrubbed instead of dropped if a blacklist or whitelist is applied.

Note that `User-Agent` is always passed, since it is required by the API. `Cookie` and `Authorization` are always scrubbed for security reasons.