### PR TITLE
Drop support for Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,12 @@ dist: xenial
 language: python
 
 python:
-  - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"
 
 matrix:
   include:
-    - python: "2.6"
-      dist: trusty
-      env:
-      - REQUESTS="requests" # latest
     - python: "3.7"
       sudo: true
       env:

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,10 @@
 
 - [#59](https://github.com/castle/castle-python/pull/59) drop requests min version in ci
 
+### Breaking Changes:
+
+- [#57](https://github.com/castle/castle-python/pull/57) dropped support for python 2
+
 ## 2.4.0 (2019-11-20)
 
 - [#53](https://github.com/castle/castle-python/pull/53) Update whitelisting and blacklisting behavior

--- a/castle/headers_formatter.py
+++ b/castle/headers_formatter.py
@@ -1,5 +1,4 @@
 import re
-import sys
 
 
 class HeadersFormatter(object):
@@ -9,7 +8,4 @@ class HeadersFormatter(object):
 
     @staticmethod
     def split(header):
-        if sys.version_info[:2] == (2, 6):
-            return re.split(r'_|-', re.sub(re.compile(r'^HTTP(?:_|-)', re.IGNORECASE), '', header))
-        else:
-            return re.split(r'_|-', re.sub(r'^HTTP(?:_|-)', '', header, flags=re.IGNORECASE))
+        return re.split(r'_|-', re.sub(r'^HTTP(?:_|-)', '', header, flags=re.IGNORECASE))

--- a/castle/test/__init__.py
+++ b/castle/test/__init__.py
@@ -1,27 +1,8 @@
 import logging
 import sys
+import unittest
+from unittest import mock
 
-
-# The unittest module got a significant overhaul
-# in 2.7, so if we're in 2.6 we can use the backported
-# version unittest2.
-if sys.version_info[:2] == (2, 6):
-    # pylint: disable=import-error
-    import unittest2 as unittest
-else:
-    import unittest
-
-
-# Python 3 includes mocking, while 2 requires an extra module.
-if sys.version_info[0] == 2:
-    # pylint: disable=import-error
-    import mock
-else:
-    from unittest import mock
-
-if sys.version_info[:2] == (2, 6):
-    import subprocess
-    subprocess.call(["sed", "-i", "-e",  's/import _io/import io as _io/g', "/home/travis/build/castle/castle-python/.eggs/responses-0.6.2-py2.6.egg/responses.py"])
 
 TEST_MODULES = [
     'castle.test.api_test',

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-import sys
-
 try:
     from setuptools import find_packages, setup
 except ImportError:
@@ -7,11 +5,6 @@ except ImportError:
 
 from castle.version import VERSION
 
-
-if sys.version_info[:2] == (2, 6):
-    tests_require = ['responses<0.7', 'unittest2']
-else:
-    tests_require = ['responses']
 
 setup(
     name="castle",
@@ -29,9 +22,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
@@ -41,6 +31,6 @@ setup(
     install_requires=[
         'requests>=2.5',
     ],
-    tests_require=tests_require,
+    tests_require=['responses'],
     test_suite='castle.test.all'
 )


### PR DESCRIPTION
If you are still using Python 2 you can keep using previous versions of the SDK, but we will stop actively developing for Python 2. We strongly recommend that you update since Python 2 is no longer actively maintained.

Read more about the end of life for Python 2 here https://www.python.org/doc/sunset-python-2/