### PR TITLE
don't append default headers to ip_headers, drop X-Client-Id

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 ## master
 
+- dropped X-Client-Id from calculation of ip, drop appending default ip headers to the ip_header list config when config is provided (in that case default headers have to explicitly provided)
+
 ## 3.1.0 (2020-02-27)
 
 - [#61](https://github.com/castle/castle-python/pull/61) improve headers and ip extractions, improve ip_headers config, add trusted proxies config, added more events to events list

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 ## master
 
-- dropped X-Client-Id from calculation of ip, drop appending default ip headers to the ip_header list config when config is provided (in that case default headers have to explicitly provided)
+- [#64](https://github.com/castle/castle-python/pull/64)dropped X-Client-Id from calculation of ip, drop appending default ip headers to the ip_header list config when config is provided (in that case default headers have to explicitly provided)
 
 ## 3.1.0 (2020-02-27)
 

--- a/README.rst
+++ b/README.rst
@@ -44,11 +44,11 @@ import and configure the library with your Castle API secret.
     configuration.blacklisted = ['HTTP-X-header']
 
     # Castle needs the original IP of the client, not the IP of your proxy or load balancer.
-    # we try to fetch proper ip based on X-Forwarded-For, X-Client-Id or Remote-Addr headers in that order
+    # we try to fetch proper ip based on X-Forwarded-For or Remote-Addr headers in that order
     # but sometimes proper ip may be stored in different header or order could be different.
     # SDK can extract ip automatically for you, but you must configure which ip_headers you would like to use
     configuration.ip_headers = []
-    # Additionally to make X-Forwarded-For or X-Client-Id work better discovering client ip address,
+    # Additionally to make X-Forwarded-For and other headers work better discovering client ip address,
     # and not the address of a reverse proxy server, you can define trusted proxies
     # which will help to fetch proper ip from those headers
     configuration.trusted_proxies = []

--- a/castle/test/extractors/ip_test.py
+++ b/castle/test/extractors/ip_test.py
@@ -14,7 +14,7 @@ class ExtractorsIpTestCase(unittest.TestCase):
 
     def test_extract_ip_when_second_header(self):
         headers = {'Cf-Connecting-Ip': '1.2.3.4', 'X-Forwarded-For': '1.1.1.1, 1.2.2.2, 1.2.3.5'}
-        configuration.ip_headers = ["HTTP_CF_CONNECTING_IP"]
+        configuration.ip_headers = ["HTTP_CF_CONNECTING_IP", "X-Forwarded-For"]
         self.assertEqual(
             ExtractorsIp(headers).call(),
             '1.2.3.4'
@@ -22,7 +22,7 @@ class ExtractorsIpTestCase(unittest.TestCase):
 
     def test_extract_ip_when_second_header_with_different_setting(self):
         headers = {'Cf-Connecting-Ip': '1.2.3.4', 'X-Forwarded-For': '1.1.1.1, 1.2.2.2, 1.2.3.5'}
-        configuration.ip_headers = ["CF-CONNECTING-IP"]
+        configuration.ip_headers = ["CF-CONNECTING-IP", "X-Forwarded-For"]
         self.assertEqual(
             ExtractorsIp(headers).call(),
             '1.2.3.4'


### PR DESCRIPTION
also when all marked as trusted proxy - dropped fallback to Remote-Addr instead used first whatever value provided